### PR TITLE
Correct typo in long value for passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- Corrected long option value for passwords - from "passowrd" to "password"
+
 ### Removed
 - code climate badge as we don't really use it anymore
 

--- a/bin/check-tomcat-app-deployment.rb
+++ b/bin/check-tomcat-app-deployment.rb
@@ -47,7 +47,7 @@ class CheckTomcatAppDeployment < Sensu::Plugin::Check::CLI
   option :password,
          description: 'Tomcat User password',
          short: '-p PASSWORD',
-         long: '--passowrd PASSWORD',
+         long: '--password PASSWORD',
          default: 'password',
          require: true
 

--- a/bin/check-tomcat-heap-pcnt.rb
+++ b/bin/check-tomcat-heap-pcnt.rb
@@ -47,7 +47,7 @@ class CheckTomcatHeapMemory < Sensu::Plugin::Check::CLI
   option :password,
          description: 'Tomcat User password',
          short: '-p PASSWORD',
-         long: '--passowrd PASSWORD',
+         long: '--password PASSWORD',
          default: 'password',
          required: true
 


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Long form of password option should be "--password", not "--passowrd". This is a breaking change.
